### PR TITLE
Add traces_sample_rate setting

### DIFF
--- a/app/views/settings/_sentry_settings.erb
+++ b/app/views/settings/_sentry_settings.erb
@@ -8,6 +8,10 @@
   <input type="text" id="environment" value="<%= settings['environment'] %>" name="settings[environment]" style="width:100%;">
   </p>
   <p>
+  <label> <%=l(:config_traces_sample_rate) %></label>
+  <input type="number" id="traces_sample_rate" value="<%= settings['traces_sample_rate'] %>" name="settings[traces_sample_rate]" style="width:100%;" max="1.0" min="0.0" step="0.01">
+  </p>
+  <p>
   <label>Test</label>
   <button type="button" style="width: 95%" onclick="window.location.href = '/sentry'"> <%=l(:config_test_exception) %></button>
   </p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -4,3 +4,4 @@ de:
   config_environment: "Sentry environment"
   config_test_exception: "Löse Test-Fehler aus"
   config_disclamer: "Redmine muss neu gestartet werden, wenn hier Änderungen vorgenommen werden!"
+  config_traces_sample_rate: "Sentry traces_sample_rate"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,3 +4,4 @@ en:
   config_environment: "Sentry environment"
   config_test_exception: "Trigger test exception"
   config_disclamer: "You need to restart redmine, if you change configurations here!"
+  config_traces_sample_rate: "Sentry traces_sample_rate"

--- a/lib/redmine_sentry_client/helper/sentry_helper.rb
+++ b/lib/redmine_sentry_client/helper/sentry_helper.rb
@@ -7,8 +7,7 @@ module RedmineSentryClient
                     config.environment = self.environment()
                     config.breadcrumbs_logger = [:active_support_logger, :http_logger]
         
-                    # TODO: Allow customisation of traces_sample_rate
-                    config.traces_sample_rate = 0.5
+                    config.traces_sample_rate = self.traces_sample_rate()
                 end
             end
         
@@ -21,6 +20,11 @@ module RedmineSentryClient
             ## get the Sentry DSN
             def self.dsn()
                 return Setting.plugin_redmine_sentry_client['dsn']
+            end
+
+            ## get the Sentry traces_sample_rate configuration
+            def self.traces_sample_rate()
+                return Setting.plugin_redmine_sentry_client['traces_sample_rate'].to_d
             end
         end
     end    

--- a/lib/redmine_sentry_client/helper/sentry_helper.rb
+++ b/lib/redmine_sentry_client/helper/sentry_helper.rb
@@ -2,7 +2,6 @@ module RedmineSentryClient
     module Helper
         class SentryHelper
             def self.init()
-                puts "SentryHelper.init()"
                 Sentry.init do |config|
                     config.dsn = self.dsn()
                     config.environment = self.environment()


### PR DESCRIPTION
This adds a new configuration for the traces_sample_rate setting from the Sentry SDK.

Fixes: #7 