### PR TITLE
Sepcify default settings

### DIFF
--- a/app/views/settings/_sentry_settings.erb
+++ b/app/views/settings/_sentry_settings.erb
@@ -1,15 +1,18 @@
+<style>
+p input { width: 100%; }
+</style>
 <div id="senty-client-settings-container">
   <p>
   <label><%= l(:config_dsn) %></label>
-  <input type="text" id="dsn" value="<%= settings['dsn'] %>" name="settings[dsn]" style="width:100%;">
+  <%= text_field_tag 'settings[dsn]', RedmineSentryClient.dsn %>
   </p>
   <p>
   <label> <%=l(:config_environment) %></label>
-  <input type="text" id="environment" value="<%= settings['environment'] %>" name="settings[environment]" style="width:100%;">
+  <%= text_field_tag 'settings[environment]', RedmineSentryClient.environment %>
   </p>
   <p>
   <label> <%=l(:config_traces_sample_rate) %></label>
-  <input type="number" id="traces_sample_rate" value="<%= settings['traces_sample_rate'] %>" name="settings[traces_sample_rate]" style="width:100%;" max="1.0" min="0.0" step="0.01">
+  <%= number_field_tag 'settings[traces_sample_rate]', RedmineSentryClient.traces_sample_rate, :min => 0, :max => 1, :step => 0.01 %>
   </p>
   <p>
   <label>Test</label>

--- a/lib/redmine_sentry_client.rb
+++ b/lib/redmine_sentry_client.rb
@@ -1,3 +1,23 @@
 require 'redmine_sentry_client/helper/sentry_helper'
 
+module RedmineSentryClient
+
+    class << self
+
+        def traces_sample_rate
+            Setting.plugin_redmine_sentry_client['traces_sample_rate'].to_d || 0.5
+        end
+
+        def environment
+            return Setting.plugin_redmine_sentry_client['environment'] ? Setting.plugin_redmine_sentry_client['environment'] : Rails.env
+        end
+    
+        def dsn
+            return Setting.plugin_redmine_sentry_client['dsn'] || ""
+        end
+
+    end
+
+end
+
 RedmineSentryClient::Helper::SentryHelper.init()

--- a/lib/redmine_sentry_client/helper/sentry_helper.rb
+++ b/lib/redmine_sentry_client/helper/sentry_helper.rb
@@ -1,30 +1,15 @@
 module RedmineSentryClient
     module Helper
         class SentryHelper
+            
             def self.init()
                 Sentry.init do |config|
-                    config.dsn = self.dsn()
-                    config.environment = self.environment()
+                    config.dsn = RedmineSentryClient.dsn
+                    config.environment = RedmineSentryClient.environment
                     config.breadcrumbs_logger = [:active_support_logger, :http_logger]
         
-                    config.traces_sample_rate = self.traces_sample_rate()
+                    config.traces_sample_rate = RedmineSentryClient.traces_sample_rate
                 end
-            end
-        
-            ## Get the configured environment
-            ## either the config value, Rails.env or 'production'
-            def self.environment()
-                return Setting.plugin_redmine_sentry_client['environment'] ? Setting.plugin_redmine_sentry_client['environment'] : Rails.env
-            end
-        
-            ## get the Sentry DSN
-            def self.dsn()
-                return Setting.plugin_redmine_sentry_client['dsn']
-            end
-
-            ## get the Sentry traces_sample_rate configuration
-            def self.traces_sample_rate()
-                return Setting.plugin_redmine_sentry_client['traces_sample_rate'].to_d
             end
         end
     end    


### PR DESCRIPTION
This refactors the way settings are handled internally in the plugin and therefore allows for default settings.

Fixes: #8 